### PR TITLE
Deploy #221 obrigatoriedade removida em Currículos(BNCC).

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,3 @@
 [submodule "src/modules/teacher-journey"]
 	path = src/modules/teacher-journey
 	url = git@github.com:EduPrime/teacher_journey.git
-	branch = fix-#221

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "src/modules/teacher-journey"]
 	path = src/modules/teacher-journey
 	url = git@github.com:EduPrime/teacher_journey.git
+	branch = fix-#221


### PR DESCRIPTION
Disponível em: https://deploy--221.app-c6w.pages.dev/

Alterei a obrigatoriedade de currículo(BNCC) ao CADASTRAR/EDITAR registro de conteúdo. CONSULTE O LINK DO MODULO PARA MAIS DETALHES: https://github.com/EduPrime/teacher_journey/pull/24